### PR TITLE
Added 'client.id' argument in 'Call' event

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -51,7 +51,7 @@ handlers[protocol.TYPE_ID_CALL] = function(client, args) {
     client.send(JSON.stringify(msg));
   };
 
-  this.emit('call', procUri, args, cb);
+  this.emit('call', client.id, procUri, args, cb);
 };
 
 /**


### PR DESCRIPTION
As procedures could be protected or user-specific, add the client ID in the "Call" event.
