### PR TITLE
Handle errors in RPCs and optional websocket subprotocol

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -270,9 +270,11 @@ Session.prototype.call = function() {
  */
 function Client(wsuri, onconnect, onhangup, options) {
   // options for WebSocket protocol
-  var wsoptions = {
-    protocol: 'wamp'
-  };
+  var wsoptions = {};
+
+  if (!options.skipWsSubprotocol) {
+    wsoptions.protocol = options.wsProtocol || 'wamp';
+  }
   
   // create the WebSocket connection
   var ws = new WebSocket(wsuri, wsoptions);

--- a/lib/client.js
+++ b/lib/client.js
@@ -106,16 +106,28 @@ function Session(ws, onOpen, onClose, options) {
     
     var o = JSON.parse(e.data);
     if (o[1] in self._calls) {
-      if (o[0] === protocol.TYPE_ID_CALL_RESULT) {
+      var callid = o[1];
+      var deferred = self._calls[callid];
+
+      if (o[0] === protocol.TYPE_ID_CALL_RESULT) {       
         // the reply has arrived, get the deferred 
-        var callid = o[1];
-        var deferred = self._calls[callid];
         var reply = o[2];
         
         debug('[' + self._websocket.url + '] < Call result [' + callid + '] :' + reply);
         
         // finally resolve the pending deferred request
         deferred.resolve(reply);
+      } else if (o[0] === protocol.TYPE_ID_CALL_ERROR) {
+        // the error has arrived, get the deferred 
+        var error = {
+          uri: o[2],
+          desc: o[3]
+        };
+        
+        debug('[' + self._websocket.url + '] < Call error [' + callid + '] :' + error.desc);
+        
+        // finally resolve the pending deferred request
+        deferred.reject(error);
       }
     } else if (o[0] === protocol.TYPE_ID_EVENT) {
       // nop

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/nicokaiser/wamp.io.git"
+        "url": "https://github.com/mathieumg/wamp.io"
     },
-    "description": "Implementation of the WebSocket Application Messaging Protocol (WAMP) for WebSocket.IO or Engine.IO",
+    "description": "Implementation of the WebSocket Application Messaging Protocol (WAMP) for WebSocket.IO, Engine.IO or SockJS",
     "version": "0.0.4",
     "contributors": [
         {
@@ -18,15 +18,19 @@
         {
             "name": "Vito Macchia",
             "email": "vito.macchia@gmail.com"
+        },
+        {
+            "name": "Mathieu M-Gosselin",
+            "email": "mathieumg@gmail.com"
         }
     ],
     "dependencies": {
-        "debug": "*"
-      , "when": "*"
+        "debug": "*",
+        "when": "*",
+        "ws": "~0.4.25"
     },
     "devDependencies": {
-        "ws": "~0.4.25"
-      , "mocha": "*"
+        "mocha": "*"
     },
     "main": "lib/wamp.io",
     "engines": {


### PR DESCRIPTION
I split the commits in case you want to cherry-pick!

The subprotocol option change is to allow greater flexibility. For example, a server that runs wamp over SockJS understands wamp correctly, but has no subprotocol handshaking for the time being.
